### PR TITLE
Automatically run tests using GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Run tests
+on: [pull_request, push, workflow_dispatch]
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        ruby: ['2.7', '3.2']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: '${{ matrix.ruby }}'
+      - name: Run tests
+        run: bundle exec rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Run tests
-on: [pull_request, push, workflow_dispatch]
+on: push
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ['2.7', '3.2']
+        ruby: ['3.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds a [GitHub Actions](https://docs.github.com/actions) workflow that runs `bundle exec rake test` against a matrix of the latest stable Ruby 2.7 and 3.2 releases on pushes to branches and pull request heads.