### PR TITLE
Automatically publish Ruby gem on GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Publish Ruby gem
+on:
+  push:
+    tags: 'v*'
+  workflow_dispatch:
+concurrency:
+  group: '${{ github.workflow }} @ github.ref }}'
+  cancel-in-progress: true
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: '3.2'
+      - name: Build and publish to GitHub Packages
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push --key github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+        env:
+          GEM_HOST_API_KEY: 'Bearer ${{ secrets.GITHUB_TOKEN }}'
+          OWNER: '${{ github.repository_owner }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Run tests
 on: push
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ github.ref }}'
   cancel-in-progress: true
 jobs:
   test:

--- a/cinch.gemspec
+++ b/cinch.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'cinch'
   s.version = '2.3.5'
-  s.summary = 'An IRC Bot Building Framework'
+  s.summary = 'An IRC bot framework'
   s.description = 'A simple, friendly DSL for creating IRC bots'
   s.authors = ['Dominik Honnef', 'Ross Paffett']
   s.email = 'ross@rosspaffett.com'
@@ -9,4 +9,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7.0'
   s.files = Dir['LICENSE', 'README.md', '.yardopts', '{docs,lib,examples}/**/*']
   s.license = 'MIT'
+  s.metadata = {
+    # Connect Ruby gems published by .github/workflows/release.yml to GitHub repository
+    # https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry#connecting-a-package-to-a-repository
+    'github_repo' => 'ssh://github.com/blolol/cinch'
+  }
 end


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow that publishes a gem to GitHub Packages whenever a tag matching `v*` (e.g. `v2.3.5`) is pushed.